### PR TITLE
処理開始時にoffscreenが存在している場合は閉じる&処理完了時にServiceWorker内でoffscreenを閉じる

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -25,8 +25,18 @@ chrome.contextMenus.create({
 });
 
 const addLinkToClipboard = async (title: string, url: string) => {
+	const offscreenUrl = chrome.runtime.getURL("offscreen.html");
+	const existingContexts = await chrome.runtime.getContexts({
+		contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
+		documentUrls: [offscreenUrl],
+	});
+
+	if (existingContexts.length > 0) {
+		chrome.offscreen.closeDocument();
+	}
+
 	await chrome.offscreen.createDocument({
-		url: "../offscreen.html",
+		url: offscreenUrl,
 		reasons: [chrome.offscreen.Reason.CLIPBOARD],
 		justification: "Write text to the clipboard.",
 	});

--- a/src/background.ts
+++ b/src/background.ts
@@ -47,3 +47,16 @@ const addLinkToClipboard = async (title: string, url: string) => {
 		data: `[${title} ${decodeURIComponent(url)}]`,
 	});
 };
+
+chrome.runtime.onMessage.addListener((message) => {
+	if (message.type === "copy-complete") {
+		// TODO: 結果によってSnackbarを表示する
+		if (message.status === "success") {
+			// console.log("Copy succeeded:", message.message);
+		} else {
+			// console.error("Copy failed:", message.message);
+		}
+
+		chrome.offscreen.closeDocument();
+	}
+});

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -27,8 +27,21 @@ const handleClipboardWrite = async (data: string) => {
 		const textElement = document.querySelector("#text") as HTMLInputElement;
 		textElement.value = data;
 		textElement.select();
-		document.execCommand("copy");
-	} finally {
-		window.close();
+		const result = document.execCommand("copy");
+		if (result) {
+			chrome.runtime.sendMessage({
+				type: "copy-complete",
+				status: "success",
+				message: "Copy to clipboard successful",
+			});
+		} else {
+			throw new Error("Copy to clipboard failed");
+		}
+	} catch (error) {
+		chrome.runtime.sendMessage({
+			type: "copy-complete",
+			status: "error",
+			message: error.message,
+		});
 	}
 };


### PR DESCRIPTION
## 詳細
* コピーができない時がある問題への対応
* ドキュメントを参考にしてoffscreenが存在している場合は閉じるようにした
  * https://developer.chrome.com/docs/extensions/reference/api/offscreen
* また、処理完了後にoffscreen.jsの中でウィンドウを閉じるようにしていたが、ServiceWorker内でchrome APIを使って確実にoffscreenを閉じるようにした